### PR TITLE
Disable SSL when using a unix domain socket.

### DIFF
--- a/database/postgis/util.go
+++ b/database/postgis/util.go
@@ -18,7 +18,7 @@ func disableDefaultSslOnLocalhost(params string) string {
 		if strings.HasPrefix(p, "sslmode=") {
 			return params
 		}
-		if p == "host=localhost" || p == "host=127.0.0.1" {
+		if p == "host=localhost" || p == "host=127.0.0.1" || strings.HasPrefix(p,"host=/") {
 			isLocalHost = true
 		}
 	}


### PR DESCRIPTION
This disables SSL when using a unix domain socket e.g. 

`-connection="postgis:///dbname?host=/var/run/postgresql"`

to match the same happening when connecting locally via TCP.
