### PR TITLE
Use all cores for Finish, Generalize, Optimize steps.

### DIFF
--- a/database/postgis/postgis.go
+++ b/database/postgis/postgis.go
@@ -147,7 +147,7 @@ func (pg *PostGIS) Init() error {
 func (pg *PostGIS) Finish() error {
 	defer log.StopStep(log.StartStep(fmt.Sprintf("Creating geometry indices")))
 
-	worker := int(runtime.NumCPU() / 2)
+	worker := int(runtime.NumCPU())
 	if worker < 1 {
 		worker = 1
 	}
@@ -218,7 +218,7 @@ func (pg *PostGIS) GeneralizeUpdates() error {
 func (pg *PostGIS) Generalize() error {
 	defer log.StopStep(log.StartStep(fmt.Sprintf("Creating generalized tables")))
 
-	worker := int(runtime.NumCPU() / 2)
+	worker := int(runtime.NumCPU())
 	if worker < 1 {
 		worker = 1
 	}
@@ -328,7 +328,7 @@ func (pg *PostGIS) generalizeTable(table *GeneralizedTableSpec) error {
 func (pg *PostGIS) Optimize() error {
 	defer log.StopStep(log.StartStep(fmt.Sprintf("Clustering on geometry")))
 
-	worker := int(runtime.NumCPU() / 2)
+	worker := int(runtime.NumCPU())
 	if worker < 1 {
 		worker = 1
 	}


### PR DESCRIPTION
I noticed a ~20% total speedup when using 4 vs. 2 for these steps on my 4-core machine, with a small extract (sf-bayarea). Any reason not to bump this up to `numCPU`?
