### PR TITLE
Added documentation for FreeBSD port

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ Imposm contains a fixed set of the dependencies that are known to work. You need
     cd src/github.com/omniscale/imposm3
     godep go install ./...
 
+### FreeBSD
+
+On FreeBSD you can use the ports system: Simply fetch https://github.com/thomersch/imposm3-freebsd and run `make install`.
 
 Usage
 -----


### PR DESCRIPTION
On FreeBSD software is usually installed with the port system. I have created a FreeBSD port for imposm3 that makes installation significantly easier. For documentation reasons I have included a reference to that to the readme.