### PR TITLE
add wildcard match for tag deletion from hstore while importing

### DIFF
--- a/database/postgis/postgis.go
+++ b/database/postgis/postgis.go
@@ -574,6 +574,8 @@ func New(conf database.Config, m *mapping.Mapping) (database.DB, error) {
 	}
 	params = disableDefaultSsl(params)
 	params, db.Prefix = stripPrefixFromConnectionParams(params)
+	
+	fmt.Printf("prefix: %s %&s",params, db.Prefix)
 
 	for name, table := range m.Tables {
 		db.Tables[name] = NewTableSpec(db, table)

--- a/mapping/filter.go
+++ b/mapping/filter.go
@@ -2,6 +2,7 @@ package mapping
 
 import (
 	"github.com/omniscale/imposm3/element"
+        "path"
 )
 
 func (m *Mapping) NodeTagFilter() TagFilterer {
@@ -70,8 +71,10 @@ func newExcludeFilter(tags []Key) *ExcludeFilter {
 
 func (f *ExcludeFilter) Filter(tags *element.Tags) bool {
 	for k, _ := range *tags {
-		if _, ok := f.exclude[Key(k)]; ok {
-			delete(*tags, k)
+		for exkey, _ := range f.exclude {
+			if ok, _ := path.Match(string(exkey),k); ok {
+				delete(*tags, k)
+			}
 		}
 	}
 	return true

--- a/mapping/filter.go
+++ b/mapping/filter.go
@@ -74,6 +74,7 @@ func (f *ExcludeFilter) Filter(tags *element.Tags) bool {
 		for exkey, _ := range f.exclude {
 			if ok, _ := path.Match(string(exkey),k); ok {
 				delete(*tags, k)
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
Hello,

Looks like imposm is already pretty close to be a drop-in replacement for osm2pgsql (which is horrible mostly unmaintained code). So lets go and add the missing parts.

I just started with golang a few hours ago, but this part of the code has been simple enough to get it working. Unfortunately I'm not yet good enough to also add support for route relations :(

Here is what this patch does:

When working with hstore and osm data one should get rid of all the broken tags generated by (arguably broken) imports. This is where wildcards come in handy.

With this patch it will be possible to use wildcards in the exclude list specified in the json file.

Sven