### PR TITLE
MultiPolygon builder only uses members with inner or outer role.

### DIFF
--- a/geom/multipolygon.go
+++ b/geom/multipolygon.go
@@ -76,7 +76,9 @@ func buildRings(rel *element.Relation, maxRingGap float64) ([]*ring, error) {
 		if member.Way == nil {
 			continue
 		}
-		rings = append(rings, newRing(member.Way))
+		if member.Role == "inner" || member.Role == "outer" {
+			rings = append(rings, newRing(member.Way))
+		}
 	}
 
 	// create geometries for closed rings, collect incomplete rings


### PR DESCRIPTION
MultiPolygon builder should only use inner/outer members as ring parts

In the case of a building relation such as http://www.openstreetmap.org/relation/2853424#map=19/40.71317/-74.00356 composed of multiple parts, it seems like Imposm3 is interpreting the building parts that lie within the footprint as holes, when instead they should not be part of the outer multipolygon. 

This change seemed to work for me - appreciate any suggestions on what other changes may need to be made