### PR TITLE
Extended imposm3 version information with: go version, geos version, …

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,9 +6,12 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/jmhodges/levigo"
+
 	"github.com/omniscale/imposm3/cache/query"
 	"github.com/omniscale/imposm3/config"
 	"github.com/omniscale/imposm3/diff"
+	"github.com/omniscale/imposm3/geom/geos"
 	"github.com/omniscale/imposm3/import_"
 	"github.com/omniscale/imposm3/logging"
 	"github.com/omniscale/imposm3/stats"
@@ -23,6 +26,7 @@ func PrintCmds() {
 	fmt.Println("\tdiff")
 	fmt.Println("\tquery-cache")
 	fmt.Println("\tversion")
+	fmt.Println("See more: http://imposm.org/\n")
 }
 
 func Main(usage func()) {
@@ -55,7 +59,10 @@ func Main(usage func()) {
 	case "query-cache":
 		query.Query(os.Args[2:])
 	case "version":
-		fmt.Println(Version)
+		fmt.Printf("%s %s(%s-%s-%s)", Version, runtime.Version(), runtime.GOARCH, runtime.GOOS, runtime.Compiler)
+		fmt.Printf(" geos=(%s)", geos.Version())
+		fmt.Printf(" leveldb=%d.%d", levigo.GetLevelDBMajorVersion(), levigo.GetLevelDBMinorVersion())
+		fmt.Printf(" numcpu=%d\n", runtime.NumCPU())
 		os.Exit(0)
 	default:
 		usage()

--- a/geom/geos/geos.go
+++ b/geom/geos/geos.go
@@ -355,3 +355,7 @@ func (this *Geom) Bounds() Bounds {
 
 	return Bounds{minx, miny, maxx, maxy}
 }
+
+func Version() string {
+	return (C.GoString(C.GEOSversion()))
+}


### PR DESCRIPTION
Extended imposm3 version information with: go version, geos version, leveldb version, numcpu
You can Refactor - as you like ..

-- old ---

``` bash
./imposm3 version
0.1dev-20160124-1aff01c
```

-- new ---

``` bash
./imposm3 version
0.1dev-20160124-1aff01c go1.4.3(amd64-linux-gc) geos=(3.5.0-CAPI-1.9.0 r4084) leveldb=1.18 numcpu=4
```

And added website link ( http://imposm.org/ ) :

``` bash
./imposm3
Usage: ./imposm3 COMMAND [args]

Available commands:
    import
    diff
    query-cache
    version
See more: http://imposm.org/           <--- new
```
