### PR TITLE
Include replication sequence in pbf header.

### DIFF
--- a/parser/pbf/lowlevel.go
+++ b/parser/pbf/lowlevel.go
@@ -105,6 +105,7 @@ func readAndParseHeaderBlock(pos block) (*pbfHeader, error) {
 	result := &pbfHeader{}
 	timestamp := header.GetOsmosisReplicationTimestamp()
 	result.Time = time.Unix(timestamp, 0 /* nanoseconds */)
+	result.Sequence = header.GetOsmosisReplicationSequenceNumber()
 	return result, nil
 }
 
@@ -116,7 +117,8 @@ type Pbf struct {
 }
 
 type pbfHeader struct {
-	Time time.Time
+	Time     time.Time
+	Sequence int64
 }
 
 func Open(filename string) (f *Pbf, err error) {


### PR DESCRIPTION
I need this when building an OSM-replication tool based on your PBF parser (many thanks for that one).

I'm fully aware that the PBF parser isn't considered stable public API, that's OK, we're willing to take that pain (we can always vendor if needed).