### PR TITLE
Support pbf_timestamp field

### DIFF
--- a/database/postgis/fields.go
+++ b/database/postgis/fields.go
@@ -82,5 +82,6 @@ func init() {
 		"hstore_string":      &simpleColumnType{"HSTORE"},
 		"geometry":           &geometryType{"GEOMETRY"},
 		"validated_geometry": &validatedGeometryType{geometryType{"GEOMETRY"}},
+		"timestamp":          &simpleColumnType{"TIMESTAMP"},
 	}
 }

--- a/mapping/fields.go
+++ b/mapping/fields.go
@@ -405,6 +405,11 @@ func MakeSuffixReplace(fieldName string, fieldType FieldType, field Field) (Make
 }
 
 func MakePbfTimestamp(fieldName string, fieldType FieldType, field Field) (MakeValue, error) {
+
+	if config.ImportOptions.Read == "" {
+		return nil, nil
+	}
+
 	pbfFile, err := pbf.Open(config.ImportOptions.Read)
 	defer pbfFile.Close()
 


### PR DESCRIPTION
It is useful to have date of the OSM snapshot to be mapped as field into the database directly to track changes.

This introduces a new field type `pbf_timestamp` which will set the value to the timestamp defined in the PBF Header.

We use this in http://github.com/osm2vectortiles/osm2vectortiles to recognize rows that have
changed after a diff update and then rerender vector tiles that are affected by those changes. Idea came from @ImreSamu

BTW. we are huge fans of imposm3 and osm2vectortiles would never have been possible without you. Keep up the outstanding work.