### PR TITLE
Switch replication URL to HTTPS

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -210,7 +210,7 @@ To start the update process::
 
 You can stop processing new diff files SIGTERM (``crtl-c``), SIGKILL or SIGHUP. You should create systemd/upstart/init.d service for ``imposm3 run`` to always run in background.
 
-You can change to hourly updates by adding `replication_url: "http://planet.openstreetmap.org/replication/hour/"` and `replication_interval: "1h"` to the Imposm configuration.
+You can change to hourly updates by adding `replication_url: "https://planet.openstreetmap.org/replication/hour/"` and `replication_interval: "1h"` to the Imposm configuration.
 
 
 One-time update

--- a/update/state/state.go
+++ b/update/state/state.go
@@ -92,7 +92,7 @@ func FromPbf(filename string, before time.Duration) (*DiffState, error) {
 		timestamp = fstat.ModTime()
 	}
 
-	replicationUrl := "http://planet.openstreetmap.org/replication/minute/"
+	replicationUrl := "https://planet.openstreetmap.org/replication/minute/"
 
 	seq := estimateSequence(replicationUrl, timestamp)
 	if seq == 0 {


### PR DESCRIPTION
The discussion about moving OSM services to HTTPS-only continues.
Although everything should be happy following 302 redirects I thought
I'd remove one variable and move the default URL to HTTPS.

Seems to work fine for me.