### PR TITLE
[WIP] Replication improvements

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -126,7 +126,7 @@ func (o *_BaseOptions) updateFromConfig() error {
 		o.ExpireTilesZoom = 14
 	}
 
-	if conf.ReplicationInterval.Duration != 0 && o.ReplicationInterval != time.Minute {
+	if conf.ReplicationInterval.Duration != 0 && o.ReplicationInterval == time.Minute {
 		o.ReplicationInterval = conf.ReplicationInterval.Duration
 	}
 	if o.ReplicationInterval < time.Minute {

--- a/config/config.go
+++ b/config/config.go
@@ -143,7 +143,7 @@ func (o *_BaseOptions) updateFromConfig() error {
 		}
 	}
 
-	if conf.DiffStateBefore.Duration != 0 && o.DiffStateBefore == 2*time.Hour {
+	if conf.DiffStateBefore.Duration != 0 && o.DiffStateBefore == 0 {
 		o.DiffStateBefore = conf.DiffStateBefore.Duration
 	}
 	return nil
@@ -226,7 +226,7 @@ func init() {
 	ImportFlags.BoolVar(&ImportOptions.DeployProduction, "deployproduction", false, "deploy production")
 	ImportFlags.BoolVar(&ImportOptions.RevertDeploy, "revertdeploy", false, "revert deploy to production")
 	ImportFlags.BoolVar(&ImportOptions.RemoveBackup, "removebackup", false, "remove backups from deploy")
-	ImportFlags.DurationVar(&BaseOptions.DiffStateBefore, "diff-state-before", 2*time.Hour, "set initial diff sequence before")
+	ImportFlags.DurationVar(&BaseOptions.DiffStateBefore, "diff-state-before", 0, "set initial diff sequence before")
 
 	DiffFlags.StringVar(&BaseOptions.ExpireTilesDir, "expiretiles-dir", "", "write expire tiles into dir")
 	DiffFlags.IntVar(&BaseOptions.ExpireTilesZoom, "expiretiles-zoom", 14, "write expire tiles in this zoom level")

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -210,7 +210,9 @@ To start the update process::
 
 You can stop processing new diff files SIGTERM (``crtl-c``), SIGKILL or SIGHUP. You should create systemd/upstart/init.d service for ``imposm3 run`` to always run in background.
 
-You can change to hourly updates by adding `replication_url: "https://planet.openstreetmap.org/replication/hour/"` and `replication_interval: "1h"` to the Imposm configuration.
+You can change to hourly updates by adding `replication_url: "https://planet.openstreetmap.org/replication/hour/"` and `replication_interval: "1h"` to the Imposm configuration. Same for daily updates (works also for Geofabrik updates): `replication_url: "https://planet.openstreetmap.org/replication/day/"` and `replication_interval: "24h"`.
+
+At import time, Imposm compute the first diff sequence number by comparing the PBF input file timestamp and the latest state available in the remote server. Depending on the PBF generation process, this sequence number may not be correct, you can force Imposm to start with an earlier sequence number by adding a `diff_state_before` duration in your conf file. For example, `diff_state_before: 4h` will start with an initial sequence number generated 4 hours before the PBF generation time.
 
 
 One-time update

--- a/import_/import.go
+++ b/import_/import.go
@@ -125,7 +125,7 @@ func Import() {
 		osmCache.Close()
 		log.StopStep(step)
 		if config.ImportOptions.Diff {
-			diffstate, err := state.FromPbf(config.ImportOptions.Read, config.BaseOptions.DiffStateBefore)
+			diffstate, err := state.FromPbf(config.ImportOptions.Read, config.BaseOptions.DiffStateBefore, config.BaseOptions.ReplicationUrl, config.BaseOptions.ReplicationInterval)
 			if err != nil {
 				log.Print("error parsing diff state form PBF", err)
 			} else if diffstate != nil {

--- a/replication/source.go
+++ b/replication/source.go
@@ -174,7 +174,7 @@ func (d *downloader) fetchNextLoop() {
 	lastTime, err := d.stateTime(stateFile)
 	for {
 		nextSeq := d.lastSequence + 1
-		log.Print("Processing sequence ", nextSeq, err)
+		log.Print("Processing sequence ", nextSeq)
 		if err == nil {
 			nextDiffTime := lastTime.Add(d.interval)
 			if nextDiffTime.After(time.Now()) {

--- a/replication/source.go
+++ b/replication/source.go
@@ -71,13 +71,23 @@ func newDownloader(dest, url string, seq int, interval time.Duration) *downloade
 		},
 	}
 
+	var naWaittime time.Duration
+	switch interval {
+	case 24 * time.Hour:
+		naWaittime = 5 * time.Minute
+	case time.Hour:
+		naWaittime = 60 * time.Second
+	default:
+		naWaittime = 10 * time.Second
+	}
+
 	dl := &downloader{
 		baseUrl:      url,
 		dest:         dest,
 		lastSequence: seq,
 		interval:     interval,
 		errWaittime:  60 * time.Second,
-		naWaittime:   10 * time.Second,
+		naWaittime:   naWaittime,
 		sequences:    make(chan Sequence, 1),
 		client:       client,
 	}

--- a/update/run.go
+++ b/update/run.go
@@ -50,6 +50,8 @@ func Run() {
 		log.Fatal("no replicationUrl in last.state.txt " +
 			"or replication_url in -config file")
 	}
+	logger.Print("Replication URL: " + replicationUrl)
+	logger.Print("Replication interval: ", config.BaseOptions.ReplicationInterval)
 
 	downloader := replication.NewDiffDownloader(
 		config.BaseOptions.DiffDir,

--- a/update/state/state.go
+++ b/update/state/state.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"os"
 	"path"
@@ -209,6 +210,7 @@ func estimateSequence(url string, timestamp time.Time) int {
 		}
 	}
 
-	behind := state.Time.Sub(timestamp)
-	return state.Sequence - int(behind.Minutes())
+    behind := state.Time.Sub(timestamp)
+    // Sequence unit depends on replication interval (minute, hour, day).
+    return state.Sequence - int(math.Ceil(behind.Minutes() / config.BaseOptions.ReplicationInterval.Minutes()))
 }

--- a/update/state/state.go
+++ b/update/state/state.go
@@ -105,7 +105,7 @@ func FromPbf(filename string, before time.Duration) (*DiffState, error) {
 	}
 
 	// start earlier
-	seq -= int(before.Minutes())
+	seq -= int(before.Minutes() / config.BaseOptions.ReplicationInterval.Minutes())
 	return &DiffState{Time: timestamp, Url: replicationUrl, Sequence: seq}, nil
 }
 

--- a/update/state/state.go
+++ b/update/state/state.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/omniscale/imposm3/config"
 	"github.com/omniscale/imposm3/logging"
 	"github.com/omniscale/imposm3/parser/pbf"
 )
@@ -92,7 +93,10 @@ func FromPbf(filename string, before time.Duration) (*DiffState, error) {
 		timestamp = fstat.ModTime()
 	}
 
-	replicationUrl := "https://planet.openstreetmap.org/replication/minute/"
+	replicationUrl := config.BaseOptions.ReplicationUrl
+	if replicationUrl == "" {
+		replicationUrl = "https://planet.openstreetmap.org/replication/minute/"
+	}
 
 	seq := estimateSequence(replicationUrl, timestamp)
 	if seq == 0 {

--- a/update/state/state.go
+++ b/update/state/state.go
@@ -186,7 +186,7 @@ func currentState(url string) (*DiffState, error) {
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, errors.New(fmt.Sprintf("invalid repsonse: %v", resp))
+		return nil, errors.New(fmt.Sprintf("invalid response: %v", resp))
 	}
 	defer resp.Body.Close()
 	return Parse(resp.Body)
@@ -195,7 +195,7 @@ func currentState(url string) (*DiffState, error) {
 func estimateSequence(url string, timestamp time.Time) int {
 	state, err := currentState(url)
 	if err != nil {
-		// try a second time befor failing
+		// try a second time before failing
 		log.Warn("unable to fetch current state from ", url, ":", err, ", retry in 30s")
 		time.Sleep(time.Second * 30)
 		state, err = currentState(url)

--- a/update/state/state_test.go
+++ b/update/state/state_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestFromPBF(t *testing.T) {
-	state, err := FromPbf("../../parser/pbf/monaco-20150428.osm.pbf", time.Hour*1)
+	state, err := FromPbf("../../parser/pbf/monaco-20150428.osm.pbf", time.Hour*1, "", time.Minute*1)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This does a few things:
- make the run command more verbose (I feel a bit like a chicken in front of a knife when I call the `run` command and it does nothing)
- fix the config `replication_interval` not being honoured
- if it exists, use the `replicationUrl` from the config to fetch the replication state (may be because using hourly or daily diff, or because using updates from Geofabrik for example)
- take the replication interval into consideration when computing the sequence at import time

It's a bit hard to test those changes in all possible scenarios.
Unittests pass.
I'm testing with a Geofabrik dataset locally with daily diff, and planet in a server with hourly diff. I'm keeping this PR as WIP so I can make more real life tests and so you can already give some feedback.