### PR TITLE
Fix invalid sequenceNumber in last.state.txt

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -201,6 +201,7 @@ func ParseImport(args []string) Import {
 	flags.BoolVar(&opts.RevertDeploy, "revertdeploy", false, "revert deploy to production")
 	flags.BoolVar(&opts.RemoveBackup, "removebackup", false, "remove backups from deploy")
 	flags.DurationVar(&opts.Base.DiffStateBefore, "diff-state-before", 0, "set initial diff sequence before")
+	flags.DurationVar(&opts.Base.ReplicationInterval, "replication-interval", time.Minute, "replication interval as duration (1m, 1h, 24h)")
 
 	flags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s %s [args]\n\n", os.Args[0], os.Args[1])


### PR DESCRIPTION
config/config.go did not honor the replication-interval option in "import" mode.

Thus baseOpts.ReplicationUrl always ended up being set to 1 minute regardless of the option specified in config.json which will then generate an unexpected sequenceNumber in last.state.txt.