### PR TITLE
Add snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,29 @@
+name: imposm3
+base: core18
+version: '0.5.0'
+summary: Imposm imports OpenStreetMap data into PostGIS
+description: |
+  Imposm imports OpenStreetMap data into PostGIS
+  Github - https://github.com/omniscale/imposm3
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+parts:
+  imposm3:
+    plugin: go
+    source: https://github.com/omniscale/imposm3/archive/v0.5.0.tar.gz
+    go-importpath: github.com/omniscale/imposm3
+    build-packages:
+    - git
+    - build-essential
+    - libleveldb-dev
+    - libgeos-dev
+    stage-packages:
+    - libgeos-dev
+    - libleveldb-dev
+    - libsnappy-dev
+
+apps:
+  imposm3:
+    command: bin/imposm3


### PR DESCRIPTION
I've taken the first step in wrapping `imposm3` in a [snap](https://snapcraft.io/) by adding a snapcraft.yaml for the stable 0.5.0 build.  `imposm3` is a great tool (thank you!) that can be better accessible if wrapped in a snap.  Note that the `grade` is devel and  `confinement` is devmode since I thought you'd want to control the release to the snapcraft store.

```
$ cd imposm3
$ snapcraft                                                                                                                                                                                                                                                               
Launching a VM.                                                                                                                                                                                                                                                                                                        
Skipping pull imposm3 (already ran)                    
Skipping build imposm3 (already ran)                                               
Staging imposm3    
Priming imposm3                                                             
Snapping 'imposm3' |                                                                                                                                                                                                                                                                                    
Snapped imposm3_0.5.0_amd64.snap                         
$ sudo snap install --dangerous --devmode imposm3_0.5.0_amd64.snap
[sudo] password for mhwang:                                                    
imposm3 0.5.0 installed                                             
$ imposm3 --help                                          
Usage: /snap/imposm3/x1/bin/imposm3 COMMAND [args]                                                     
                                                                                                      
Available commands:                        
        import                                                           
        diff                                                
        run                                                            
        query-cache                                              
        version                                          
[Dec 20 23:49:59] invalid command: '--help' 
```