### PR TITLE
Log time since in seconds

### DIFF
--- a/update/run.go
+++ b/update/run.go
@@ -107,7 +107,7 @@ func Run(baseOpts config.Base) {
 			seqId := seq.Sequence
 			seqTime := seq.Time
 			for {
-				log.Printf("[info] Importing #%d including changes till %s (%s behind)", seqId, seqTime, time.Since(seqTime).Truncate(time.Second))
+				log.Printf("[info] Importing #%d including changes till %s (%s behind)", seqId, seqTime, time.Since(seqTime).Seconds())
 				finishedImport := log.Step(fmt.Sprintf("Importing #%d", seqId))
 
 				err := Update(baseOpts, fname, geometryLimiter, tileExpireor, osmCache, diffCache, false)

--- a/update/run.go
+++ b/update/run.go
@@ -134,7 +134,7 @@ func Run(baseOpts config.Base) {
 				}
 
 				if err != nil {
-					log.Printf("[error] Importing #%s: %s", seqId, err)
+					log.Printf("[error] Importing #%d: %s", seqId, err)
 					log.Println("[info] Retrying in", exp.Duration())
 					// TODO handle <-sigc during wait
 					exp.Wait()

--- a/update/run.go
+++ b/update/run.go
@@ -107,7 +107,7 @@ func Run(baseOpts config.Base) {
 			seqId := seq.Sequence
 			seqTime := seq.Time
 			for {
-				log.Printf("[info] Importing #%d including changes till %s (%s behind)", seqId, seqTime, time.Since(seqTime).Seconds())
+				log.Printf("[info] Importing #%d including changes till %s (%f behind)", seqId, seqTime, time.Since(seqTime).Seconds())
 				finishedImport := log.Step(fmt.Sprintf("Importing #%d", seqId))
 
 				err := Update(baseOpts, fname, geometryLimiter, tileExpireor, osmCache, diffCache, false)


### PR DESCRIPTION
src/github.com/omniscale/imposm3/update/run.go:110: time.Since(seqTime).Truncate undefined (type time.Duration has no field or method Truncate)

Duration in seconds could be gotten by using 
time.Since(seqTime).Seconds()