### PR TITLE
Post Replication SQL Hook

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,19 +12,20 @@ import (
 )
 
 type Config struct {
-	CacheDir            string          `json:"cachedir"`
-	DiffDir             string          `json:"diffdir"`
-	Connection          string          `json:"connection"`
-	MappingFile         string          `json:"mapping"`
-	LimitTo             string          `json:"limitto"`
-	LimitToCacheBuffer  float64         `json:"limitto_cache_buffer"`
-	Srid                int             `json:"srid"`
-	Schemas             Schemas         `json:"schemas"`
-	ExpireTilesDir      string          `json:"expiretiles_dir"`
-	ExpireTilesZoom     int             `json:"expiretiles_zoom"`
-	ReplicationUrl      string          `json:"replication_url"`
-	ReplicationInterval MinutesInterval `json:"replication_interval"`
-	DiffStateBefore     MinutesInterval `json:"diff_state_before"`
+	CacheDir             string          `json:"cachedir"`
+	DiffDir              string          `json:"diffdir"`
+	Connection           string          `json:"connection"`
+	MappingFile          string          `json:"mapping"`
+	LimitTo              string          `json:"limitto"`
+	LimitToCacheBuffer   float64         `json:"limitto_cache_buffer"`
+	Srid                 int             `json:"srid"`
+	Schemas              Schemas         `json:"schemas"`
+	ExpireTilesDir       string          `json:"expiretiles_dir"`
+	ExpireTilesZoom      int             `json:"expiretiles_zoom"`
+	ReplicationUrl       string          `json:"replication_url"`
+	ReplicationInterval  MinutesInterval `json:"replication_interval"`
+	PostReplicationQuery string          `json:"post_replication_query"`
+	DiffStateBefore      MinutesInterval `json:"diff_state_before"`
 }
 
 type Schemas struct {
@@ -40,22 +41,23 @@ const defaultSchemaProduction = "public"
 const defaultSchemaBackup = "backup"
 
 type Base struct {
-	Connection          string
-	CacheDir            string
-	DiffDir             string
-	MappingFile         string
-	Srid                int
-	LimitTo             string
-	LimitToCacheBuffer  float64
-	ConfigFile          string
-	Httpprofile         string
-	Quiet               bool
-	Schemas             Schemas
-	ExpireTilesDir      string
-	ExpireTilesZoom     int
-	ReplicationUrl      string
-	ReplicationInterval time.Duration
-	DiffStateBefore     time.Duration
+	Connection           string
+	CacheDir             string
+	DiffDir              string
+	MappingFile          string
+	Srid                 int
+	LimitTo              string
+	LimitToCacheBuffer   float64
+	ConfigFile           string
+	Httpprofile          string
+	Quiet                bool
+	Schemas              Schemas
+	ExpireTilesDir       string
+	ExpireTilesZoom      int
+	ReplicationUrl       string
+	ReplicationInterval  time.Duration
+	PostReplicationQuery string
+	DiffStateBefore      time.Duration
 }
 
 func (o *Base) updateFromConfig() error {
@@ -130,6 +132,7 @@ func (o *Base) updateFromConfig() error {
 		o.ReplicationInterval = time.Minute
 	}
 	o.ReplicationUrl = conf.ReplicationUrl
+	o.PostReplicationQuery = conf.PostReplicationQuery
 
 	if o.DiffDir == "" {
 		if conf.DiffDir == "" {

--- a/update/process.go
+++ b/update/process.go
@@ -111,20 +111,7 @@ func Update(
 		return err
 	}
 
-	tagmapping, err := mapping.FromFile(baseOpts.MappingFile)
-	if err != nil {
-		return err
-	}
-
-	dbConf := database.Config{
-		ConnectionParams: baseOpts.Connection,
-		Srid:             baseOpts.Srid,
-		// we apply diff imports on the Production schema
-		ImportSchema:     baseOpts.Schemas.Production,
-		ProductionSchema: baseOpts.Schemas.Production,
-		BackupSchema:     baseOpts.Schemas.Backup,
-	}
-	db, err := database.Open(dbConf, &tagmapping.Conf)
+	db, tagmapping, err := dbFromConf(baseOpts)
 	if err != nil {
 		return errors.Wrap(err, "opening database")
 	}
@@ -424,4 +411,22 @@ func Update(
 		}
 	}
 	return nil
+}
+
+func dbFromConf(baseOpts config.Base) (database.DB, *mapping.Mapping, error) {
+	tagmapping, err := mapping.FromFile(baseOpts.MappingFile)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dbConf := database.Config{
+		ConnectionParams: baseOpts.Connection,
+		Srid:             baseOpts.Srid,
+		// we apply diff imports on the Production schema
+		ImportSchema:     baseOpts.Schemas.Production,
+		ProductionSchema: baseOpts.Schemas.Production,
+		BackupSchema:     baseOpts.Schemas.Backup,
+	}
+	db, err := database.Open(dbConf, &tagmapping.Conf)
+	return db, tagmapping, err
 }

--- a/update/run.go
+++ b/update/run.go
@@ -147,14 +147,14 @@ func Run(baseOpts config.Base) {
 			if os.Getenv("IMPOSM3_SINGLE_DIFF") != "" {
 				return
 			}
-			if time.Since(seqTime) < baseOpts.ReplicationInterval {
-				postUpdateHook(baseOpts)
+			if baseOpts.PostReplicationQuery != "" && time.Since(seqTime) < baseOpts.ReplicationInterval {
+				postReplicationHook(baseOpts)
 			}
 		}
 	}
 }
 
-func postUpdateHook(baseOpts config.Base) {
+func postReplicationHook(baseOpts config.Base) {
 	db, _, err := dbFromConf(baseOpts)
 	if err != nil {
 		log.Println("[error] Opening connection for post-update hooks", err)
@@ -165,7 +165,9 @@ func postUpdateHook(baseOpts config.Base) {
 		log.Println("[error] Post-update hook is not a PostGIS connection")
 		return
 	}
-	_, err = pg.Db.Exec("CREATE TABLE dummy();")
+	log.Println("[info] Calling Post Replication Script")
+	log.Printf("[debug] Executing SQL: %s", baseOpts.PostReplicationQuery)
+	_, err = pg.Db.Exec(baseOpts.PostReplicationQuery)
 	if err != nil {
 		log.Println("[error] Cannot apply post-update hook", err)
 		return


### PR DESCRIPTION
As requested by @giggls a post replication hook is implemented: E.g. when materialised views need updating after an OSM update import has been completed. To reduce impact during catch-up, it is only applied on the most recent update.

A configuration option has been added to the JSON file, which can now carry an SQL query that is executed.

If you have any questions, let us know. We will be both at FOSSGIS in Dresden, in case there is a need for discussion IRL.