### PR TITLE
writer: Transform way id on insertion only

### DIFF
--- a/test/single_table.osc
+++ b/test/single_table.osc
@@ -23,4 +23,9 @@
       <tag k="building" v="office"/>
     </relation>
   </modify>
+
+  <modify>
+    <node id="20002" version="2" timestamp="2011-11-11T00:11:11Z" lat="43" lon="13"/>
+  </modify>
+
 </osmChange>

--- a/test/single_table_test.go
+++ b/test/single_table_test.go
@@ -111,6 +111,7 @@ func TestSingleTable(t *testing.T) {
 		ts.assertHstore(t, []checkElem{
 			{"osm_all", -20201, "*", map[string]string{"random": "tag", "highway": "yes"}},
 		})
+		ts.assertGeomLength(t, checkElem{"osm_all", -20201, "*", nil}, 111319.5)
 	})
 
 	t.Run("NonMappedClosedWayIsMissing", func(t *testing.T) {
@@ -207,6 +208,10 @@ func TestSingleTable(t *testing.T) {
 		if len(rows) != 1 {
 			t.Errorf("found duplicate row: %v", rows)
 		}
+	})
+
+	t.Run("ModifiedWayGeometryAfterNodeMoved", func(t *testing.T) {
+		ts.assertGeomLength(t, checkElem{"osm_all", -20201, "*", nil}, 222639)
 	})
 
 	t.Run("Cleanup", func(t *testing.T) {


### PR DESCRIPTION
When using `singleIdSpace`, negative way ids should only be used for insertion in db,
and not as a reference in diffCache.

This should fix #173 