### PR TITLE
Remove logic to not build GEOS geoms for linestrings

### DIFF
--- a/writer/ways.go
+++ b/writer/ways.go
@@ -141,31 +141,6 @@ func (ww *WayWriter) buildAndInsert(
 	// make copy to avoid interference with polygon/linestring matches
 	way := osm.Way(*w)
 
-	// Shortcut for non-clipped LineStrings:
-	// We don't need any function from GEOS, so we can directly create the WKB hex string.
-	if ww.limiter == nil && !isPolygon {
-		wkb, err := geomp.NodesAsEWKBHexLineString(w.Nodes, ww.srid)
-		if err != nil {
-			return err, false
-		}
-		geom := geomp.Geometry{Wkb: wkb}
-		if err := ww.inserter.InsertLineString(w.Element, geom, matches); err != nil {
-			return err, false
-		}
-		return nil, true
-	}
-	// TODO: We could also apply this shortcut for simple Polygons that we we don't
-	// need to make valid (e.g. no holes, only 4 points).
-	// However, this does not work with (Webmerc)Area columns, unless we have
-	// a non-GEOS implementation.
-	// if ww.limiter == nil && isPolygon && len(w.Nodes) <= 5 {
-	// 	geom := geomp.Geometry{Wkb: geomp.WayAsEWKBHexPolygon(w.Nodes, ww.srid)}
-	// 	if err := ww.inserter.InsertPolygon(w.Element, geom, matches); err != nil {
-	// 		return err, false
-	// 	}
-	// 	return nil, true
-	// }
-
 	var err error
 	var geosgeom *geos.Geom
 


### PR DESCRIPTION
Fixes #227

GEOS geometries are necessary for geojson_intersects and geojson_intersects_feature, and the performance improvement from not generating them are negligible.

In #227 we both thought that GEOS geometries for linestrings would be a performance hit but when I benchmarked this change, I found finding a performance difference difficult. An upper bound is a 3% increase to import time in my tests, which were done with

```sh
cmd/imposm/imposm import -mapping example-mapping.yml \
-connection 'postgis: host=/var/run/postgresql dbname=imposmtest' \
-overwritecache -diff \
-read $HOME/osm/planet/british-columbia-200215.osm.pbf -write
```

The alternative solution would be passing information to `buildAndInsert` about if the way needs an area column, `geojson_intersects`, or `geojson_intersects_feature`. This would add complexity and possible bugs for minimal gains. With the possible bugs, I feel removing the logic completely is a better solution.

There is another bug present with some geojson files which I am working at reducing, but this fixes #227.