### PR TITLE
On import ignore negative timestamp from OSM extract #244

### DIFF
--- a/import_/state.go
+++ b/import_/state.go
@@ -23,7 +23,7 @@ func estimateFromPBF(filename string, before time.Duration, replicationURL strin
 	header, err := pbfparser.Header()
 
 	var timestamp time.Time
-	if err == nil && header.Time.Unix() != 0 {
+	if err == nil && header.Time.Unix() > 0 {
 		timestamp = header.Time
 	} else {
 		fstat, err := os.Stat(filename)


### PR DESCRIPTION
OSM Extract from OSM-FR have invalid timestamp in the header. Ignore the value to avoid writing an invalid state file.