### PR TITLE
Shutdown properly the process when using IMPOSM3_SINGLE_DIFF.

### DIFF
--- a/update/run.go
+++ b/update/run.go
@@ -150,6 +150,7 @@ func Run(baseOpts config.Base) {
 				}
 			}
 			if os.Getenv("IMPOSM3_SINGLE_DIFF") != "" {
+				shutdown()
 				return
 			}
 		}


### PR DESCRIPTION
When using `IMPOSM3_SINGLE_DIFF`, the process was not properly shutdown and if the update was quick (see #223), the expired tiles were not written on the disk.