### PR TITLE
Don't skip 4 corner geometry validation

### DIFF
--- a/writer/ways.go
+++ b/writer/ways.go
@@ -147,10 +147,7 @@ func (ww *WayWriter) buildAndInsert(
 	if isPolygon {
 		geosgeom, err = geomp.Polygon(g, way.Nodes)
 		if err == nil {
-			if g.NumCoordinates(geosgeom) > 5 {
-				// only check for valididty for non-simple geometries
-				geosgeom, err = g.MakeValid(geosgeom)
-			}
+			geosgeom, err = g.MakeValid(geosgeom)
 		}
 	} else {
 		geosgeom, err = geomp.LineString(g, way.Nodes)


### PR DESCRIPTION
These can be invalid in some cases like a figure-of-eight shape. Because there are so few triangle geometries and they are quick to validate, it's simplest to just remove the special casing of small geoms.

I did a set of test imports and found no performance difference.

Fixes #249
Fixes #221