### PR TITLE
Fix TestFromPBF on Arch Linux

### DIFF
--- a/import_/state_test.go
+++ b/import_/state_test.go
@@ -57,7 +57,7 @@ func TestFromPBF(t *testing.T) {
 			url:         "https://unknownurl_planet.openstreetmap.org/replication/day/",
 			before:      time.Hour * 24 * 3,
 			interval:    time.Hour * 24,
-			errContains: "no such host",
+			errContains: "No address associated with hostname",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
```
--- FAIL: TestFromPBF (2.38s)
    --- FAIL: TestFromPBF/unable_to_fetch_current_state (2.00s)
        state_test.go:69: expected error with "no such host", got fetching current sequence for estimated import sequence: fetching current state: Get "https://unknownurl_planet.openstreetmap.org/replication/day/state.txt": dial tcp: lookup unknownurl_planet.openstreetmap.org: No address associated with hostname
FAIL
```

AUR package: https://aur.archlinux.org/packages/imposm/