### PR TITLE
Allow expiretiles_zoom to be set in config JSON

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -187,6 +187,16 @@ func addBaseFlags(opts *Base, flags *flag.FlagSet) {
 	flags.StringVar(&opts.Schemas.Backup, "dbschema-backup", defaultSchemaBackup, "db schema for backups")
 }
 
+func isFlagActual(flags *flag.FlagSet, name string) bool {
+	found := false
+	flags.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
+}
+
 func ParseImport(args []string) Import {
 	flags := flag.NewFlagSet("import", flag.ExitOnError)
 	opts := Import{}
@@ -254,6 +264,11 @@ func ParseDiffImport(args []string) (Base, []string) {
 		log.Fatal(err)
 	}
 
+	// If expiretiles-zoom hasn't been explicitly set on the command-line, use the
+	// value from config.json or fall back to the default value.
+	if !isFlagActual(flags, "expiretiles-zoom") {
+		flags.Set("expiretiles-zoom", "0")
+	}
 	err = opts.updateFromConfig()
 	if err != nil {
 		log.Fatal(err)
@@ -292,6 +307,11 @@ func ParseRunImport(args []string) Base {
 		log.Fatal(err)
 	}
 
+	// If expiretiles-zoom hasn't been explicitly set on the command-line, use the
+	// value from config.json or fall back to the default value.
+	if !isFlagActual(flags, "expiretiles-zoom") {
+		flags.Set("expiretiles-zoom", "0")
+	}
 	err = opts.updateFromConfig()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Before this change, the default value for the `-expiretiles-zoom` command-line flag, used by the `diff` and `run` commands, would always overwrite whatever value was set for `expiretiles_zoom` in the config JSON. This change allows for four options:

- No flag value, no config value: default value used
- No flag value, config value: config value used
- Flag value, no config value: flag value used
- Both flag and config value: flag value used

Fixes omniscale/imposm3#181.