### PR TITLE
Force geometry type to 'Geometry' on generalized table #262

### DIFF
--- a/database/postgis/columns.go
+++ b/database/postgis/columns.go
@@ -44,7 +44,7 @@ func (t *geometryType) PrepareInsertSQL(i int, spec *TableSpec) string {
 }
 
 func (t *geometryType) GeneralizeSQL(colSpec *ColumnSpec, spec *GeneralizedTableSpec) string {
-	return fmt.Sprintf(`ST_SimplifyPreserveTopology("%s", %f) as "%s"`,
+	return fmt.Sprintf(`ST_SimplifyPreserveTopology("%s", %f)::Geometry as "%s"`,
 		colSpec.Name, spec.Tolerance, colSpec.Name,
 	)
 }
@@ -58,7 +58,7 @@ func (t *validatedGeometryType) GeneralizeSQL(colSpec *ColumnSpec, spec *General
 		// TODO return warning earlier
 		log.Printf("[warn] validated_geometry column returns polygon geometries for %s", spec.FullName)
 	}
-	return fmt.Sprintf(`ST_Buffer(ST_SimplifyPreserveTopology("%s", %f), 0) as "%s"`,
+	return fmt.Sprintf(`ST_Buffer(ST_SimplifyPreserveTopology("%s", %f), 0)::Geometry as "%s"`,
 		colSpec.Name, spec.Tolerance, colSpec.Name,
 	)
 }


### PR DESCRIPTION
Geometry column type of generalized table if left to Postgres on `CREATE TABLE ... AS` based on content.

But when the table initially created for polygon and a multi-polygon come up in the update, it fails with `Geometry type (MultiPolygon) does not match column type (Polygon)`.

So force the type of the geometry column to `Geometry` to accept polygon and multipolygon.
The same is already done for imported table from OSM polygons.