### PR TITLE
Make sure that only polygons are inserted into Generalized tables

### DIFF
--- a/database/postgis/columns.go
+++ b/database/postgis/columns.go
@@ -44,7 +44,7 @@ func (t *geometryType) PrepareInsertSQL(i int, spec *TableSpec) string {
 }
 
 func (t *geometryType) GeneralizeSQL(colSpec *ColumnSpec, spec *GeneralizedTableSpec) string {
-	return fmt.Sprintf(`ST_SimplifyPreserveTopology("%s", %f) as "%s"`,
+	return fmt.Sprintf(`ST_SimplifyPreserveTopology("%s", %f)::Geometry as "%s"`,
 		colSpec.Name, spec.Tolerance, colSpec.Name,
 	)
 }
@@ -58,7 +58,7 @@ func (t *validatedGeometryType) GeneralizeSQL(colSpec *ColumnSpec, spec *General
 		// TODO return warning earlier
 		log.Printf("[warn] validated_geometry column returns polygon geometries for %s", spec.FullName)
 	}
-	return fmt.Sprintf(`ST_Buffer(ST_SimplifyPreserveTopology("%s", %f), 0) as "%s"`,
+	return fmt.Sprintf(`ST_Buffer(ST_SimplifyPreserveTopology("%s", %f), 0)::Geometry as "%s"`,
 		colSpec.Name, spec.Tolerance, colSpec.Name,
 	)
 }

--- a/database/postgis/columns.go
+++ b/database/postgis/columns.go
@@ -38,13 +38,13 @@ func (t *geometryType) Name() string {
 }
 
 func (t *geometryType) PrepareInsertSQL(i int, spec *TableSpec) string {
-	return fmt.Sprintf("$%d::Geometry",
+	return fmt.Sprintf("$%d::Geometry(geometry)",
 		i,
 	)
 }
 
 func (t *geometryType) GeneralizeSQL(colSpec *ColumnSpec, spec *GeneralizedTableSpec) string {
-	return fmt.Sprintf(`ST_SimplifyPreserveTopology("%s", %f)::Geometry as "%s"`,
+	return fmt.Sprintf(`ST_SimplifyPreserveTopology("%s", %f)::Geometry(geometry) as "%s"`,
 		colSpec.Name, spec.Tolerance, colSpec.Name,
 	)
 }
@@ -58,7 +58,7 @@ func (t *validatedGeometryType) GeneralizeSQL(colSpec *ColumnSpec, spec *General
 		// TODO return warning earlier
 		log.Printf("[warn] validated_geometry column returns polygon geometries for %s", spec.FullName)
 	}
-	return fmt.Sprintf(`ST_Buffer(ST_SimplifyPreserveTopology("%s", %f), 0)::Geometry as "%s"`,
+	return fmt.Sprintf(`ST_Buffer(ST_SimplifyPreserveTopology("%s", %f), 0)::Geometry(geometry) as "%s"`,
 		colSpec.Name, spec.Tolerance, colSpec.Name,
 	)
 }


### PR DESCRIPTION
Fixes #262 
Replaces #263

It is possible for a polygon to turn into a MP after a buffer and simplify, so this uses ST_Dump to turn any MPs into simple polygons. This only seemed to turn up with PostGIS 3.

Tested with a dataset that triggered #262 but #263 did not fix.

As this fixes an unable to update issue that multiple people have encountered, it would be good to get it looked at and into a release soon.