### PR TITLE
Fixed memberIndex detection

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -37,7 +37,7 @@ type Inserter interface {
 	InsertPoint(osm.Element, geom.Geometry, []mapping.Match) error
 	InsertLineString(osm.Element, geom.Geometry, []mapping.Match) error
 	InsertPolygon(osm.Element, geom.Geometry, []mapping.Match) error
-	InsertRelationMember(osm.Relation, osm.Member, geom.Geometry, []mapping.Match) error
+	InsertRelationMember(osm.Relation, osm.Member, int, geom.Geometry, []mapping.Match) error
 }
 
 type Deployer interface {
@@ -102,7 +102,7 @@ func (n *nullDb) Abort() error                                                  
 func (n *nullDb) InsertPoint(osm.Element, geom.Geometry, []mapping.Match) error      { return nil }
 func (n *nullDb) InsertLineString(osm.Element, geom.Geometry, []mapping.Match) error { return nil }
 func (n *nullDb) InsertPolygon(osm.Element, geom.Geometry, []mapping.Match) error    { return nil }
-func (n *nullDb) InsertRelationMember(osm.Relation, osm.Member, geom.Geometry, []mapping.Match) error {
+func (n *nullDb) InsertRelationMember(osm.Relation, osm.Member, int, geom.Geometry, []mapping.Match) error {
 	return nil
 }
 

--- a/database/postgis/postgis.go
+++ b/database/postgis/postgis.go
@@ -511,9 +511,9 @@ func (pg *PostGIS) InsertPolygon(elem osm.Element, geom geom.Geometry, matches [
 	return nil
 }
 
-func (pg *PostGIS) InsertRelationMember(rel osm.Relation, m osm.Member, geom geom.Geometry, matches []mapping.Match) error {
+func (pg *PostGIS) InsertRelationMember(rel osm.Relation, m osm.Member, mi int, geom geom.Geometry, matches []mapping.Match) error {
 	for _, match := range matches {
-		row := match.MemberRow(&rel, &m, &geom)
+		row := match.MemberRow(&rel, &m, mi, &geom)
 		if err := pg.txRouter.Insert(match.Table.Name, row); err != nil {
 			return err
 		}

--- a/mapping/columns.go
+++ b/mapping/columns.go
@@ -48,7 +48,7 @@ func init() {
 }
 
 type MakeValue func(string, *osm.Element, *geom.Geometry, Match) interface{}
-type MakeMemberValue func(*osm.Relation, *osm.Member, Match) interface{}
+type MakeMemberValue func(*osm.Relation, *osm.Member, int, Match) interface{}
 
 type MakeMakeValue func(string, ColumnType, config.Column) (MakeValue, error)
 
@@ -102,25 +102,20 @@ func ValueName(val string, elem *osm.Element, geom *geom.Geometry, match Match) 
 	return match.Value
 }
 
-func RelationMemberType(rel *osm.Relation, member *osm.Member, match Match) interface{} {
+func RelationMemberType(rel *osm.Relation, member *osm.Member, memberIndex int, match Match) interface{} {
 	return member.Type
 }
 
-func RelationMemberRole(rel *osm.Relation, member *osm.Member, match Match) interface{} {
+func RelationMemberRole(rel *osm.Relation, member *osm.Member, memberIndex int, match Match) interface{} {
 	return member.Role
 }
 
-func RelationMemberID(rel *osm.Relation, member *osm.Member, match Match) interface{} {
+func RelationMemberID(rel *osm.Relation, member *osm.Member, memberIndex int, match Match) interface{} {
 	return member.ID
 }
 
-func RelationMemberIndex(rel *osm.Relation, member *osm.Member, match Match) interface{} {
-	for i := range rel.Members {
-		if rel.Members[i].ID == member.ID {
-			return i
-		}
-	}
-	return -1
+func RelationMemberIndex(rel *osm.Relation, member *osm.Member, memberIndex int, match Match) interface{} {
+	return memberIndex
 }
 
 func Direction(val string, elem *osm.Element, geom *geom.Geometry, match Match) interface{} {

--- a/mapping/matcher.go
+++ b/mapping/matcher.go
@@ -118,8 +118,8 @@ func (m *Match) Row(elem *osm.Element, geom *geom.Geometry) []interface{} {
 	return m.builder.MakeRow(elem, geom, *m)
 }
 
-func (m *Match) MemberRow(rel *osm.Relation, member *osm.Member, geom *geom.Geometry) []interface{} {
-	return m.builder.MakeMemberRow(rel, member, geom, *m)
+func (m *Match) MemberRow(rel *osm.Relation, member *osm.Member, memberIndex int, geom *geom.Geometry) []interface{} {
+	return m.builder.MakeMemberRow(rel, member, memberIndex, geom, *m)
 }
 
 type tagMatcher struct {
@@ -244,7 +244,7 @@ func (v *valueBuilder) Value(elem *osm.Element, geom *geom.Geometry, match Match
 	return nil
 }
 
-func (v *valueBuilder) MemberValue(rel *osm.Relation, member *osm.Member, geom *geom.Geometry, match Match) interface{} {
+func (v *valueBuilder) MemberValue(rel *osm.Relation, member *osm.Member, memberIndex int, geom *geom.Geometry, match Match) interface{} {
 	if v.colType.Func != nil {
 		if v.colType.FromMember {
 			if member.Element == nil {
@@ -255,7 +255,7 @@ func (v *valueBuilder) MemberValue(rel *osm.Relation, member *osm.Member, geom *
 		return v.colType.Func(rel.Tags[string(v.key)], &rel.Element, geom, match)
 	}
 	if v.colType.MemberFunc != nil {
-		return v.colType.MemberFunc(rel, member, match)
+		return v.colType.MemberFunc(rel, member, memberIndex, match)
 	}
 	return nil
 }
@@ -272,10 +272,10 @@ func (r *rowBuilder) MakeRow(elem *osm.Element, geom *geom.Geometry, match Match
 	return row
 }
 
-func (r *rowBuilder) MakeMemberRow(rel *osm.Relation, member *osm.Member, geom *geom.Geometry, match Match) []interface{} {
+func (r *rowBuilder) MakeMemberRow(rel *osm.Relation, member *osm.Member, memberIndex int, geom *geom.Geometry, match Match) []interface{} {
 	var row []interface{}
 	for _, column := range r.columns {
-		row = append(row, column.MemberValue(rel, member, geom, match))
+		row = append(row, column.MemberValue(rel, member, memberIndex, geom, match))
 	}
 	return row
 }

--- a/writer/relations.go
+++ b/writer/relations.go
@@ -55,8 +55,8 @@ func NewRelationWriter(
 		polygonMatcher:        matcher,
 		relationMatcher:       relMatcher,
 		relationMemberMatcher: relMemberMatcher,
-		rel:    rel,
-		maxGap: maxGap,
+		rel:                   rel,
+		maxGap:                maxGap,
 	}
 	rw.OsmElemWriter.writer = &rw
 	return &rw.OsmElemWriter
@@ -250,7 +250,7 @@ func handleRelationMembers(rw *RelationWriter, r *osm.Relation, geos *geosp.Geos
 		}
 	}
 
-	for _, m := range r.Members {
+	for mi, m := range r.Members {
 		var g *geosp.Geom
 		var err error
 		if m.Node != nil {
@@ -277,7 +277,7 @@ func handleRelationMembers(rw *RelationWriter, r *osm.Relation, geos *geosp.Geos
 		}
 		rel := osm.Relation(*r)
 		rel.ID = rw.relID(r.ID)
-		rw.inserter.InsertRelationMember(rel, m, gelem, relMemberMatches)
+		rw.inserter.InsertRelationMember(rel, m, mi, gelem, relMemberMatches)
 	}
 	return true
 }


### PR DESCRIPTION
Same member could be used multiple times in relation.
Old code used index of first occurance of the member for all occurances.

e.g. after import https://www.openstreetmap.org/relation/11777666 this relation will result two last members with memberIndex = 50.