### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Create a [Go workspace](http://golang.org/doc/code.html) by creating the `GOPATH
     mkdir -p go
     cd go
     export GOPATH=`pwd`
+If you have Go >=1.16, you need to run this command to not use module-aware mode:
+
+    go env -w GO111MODULE=auto
 
 Get the code and install Imposm:
 


### PR DESCRIPTION
It otherwise throws this error:
```
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

Solution found here: https://stackoverflow.com/a/68508392/