### PR TITLE
update geos link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ GEOS >=3.2 is recommended, since it became much more robust when handling invali
 
 
 [libleveldb]: https://github.com/google/leveldb/
-[libgeos]: http://trac.osgeo.org/geos/
+[libgeos]: https://libgeos.org/
 
 #### Compile
 


### PR DESCRIPTION
The current OSGeo4W version is built against GEOS 3.12.0 and silently crashes - with GEOS 3.11.2 is was apparently still fine.  Didn't try it with GEOS 3.12.0 on Linux yet, but I see that the Linux binaries still ship GEOS 3.7.3.