### PR TITLE
Fix generalized diff import

### DIFF
--- a/database/postgis/postgis.go
+++ b/database/postgis/postgis.go
@@ -554,7 +554,7 @@ func (pg *PostGIS) sortedGeneralizedTables() []string {
 	for len(pg.GeneralizedTables) > len(sorted) {
 		for _, tbl := range pg.GeneralizedTables {
 			if _, ok := added[tbl.Name]; !ok {
-				if tbl.Source != nil || added[tbl.SourceGeneralized.Name] {
+				if tbl.SourceGeneralized == nil || added[tbl.SourceGeneralized.Name] {
 					added[tbl.Name] = true
 					sorted = append(sorted, tbl.Name)
 				}

--- a/database/postgis/spec.go
+++ b/database/postgis/spec.go
@@ -221,10 +221,16 @@ func (spec *GeneralizedTableSpec) InsertSQL() string {
 		where += " AND (" + spec.Where + ")"
 	}
 
+	var sourceTable string
+	if spec.SourceGeneralized != nil {
+		sourceTable = spec.SourceGeneralized.FullName
+	} else {
+		sourceTable = spec.Source.FullName
+	}
 	columnSQL := strings.Join(cols, ",\n")
 	sql := fmt.Sprintf(`INSERT INTO "%s"."%s" (SELECT %s FROM "%s"."%s"%s)`,
 		spec.Schema, spec.FullName, columnSQL, spec.Source.Schema,
-		spec.Source.FullName, where)
+		sourceTable, where)
 	return sql
 
 }


### PR DESCRIPTION
Recently, we got some GEOS errors during diff imports. Here's one example from the Postgres logs:

```ERROR:  GEOSTopologyPreserveSimplify: IllegalArgumentException: CGAlgorithmsDD::orientationIndex encountered NaN/Inf numbers```

It happened while updating generalized tables. The Postgres logs also showed that the source of the failing INSERTs was the original table, not the previous generalized table that was specified in the mapping. It seems that radically simplifying the original geometry in one go, while skipping over several intermediate tables, can lead to mathematical problems in GEOSTopologyPreserveSimplify (and sometimes also the following GEOSBuffer).

This PR modifies diff imports to use the same way for determining the source table as in the initial import. Additionally, it corrects the order of generalized tables: Previously, `sortedGeneralizedTables()` didn't work because `Source` is always filled. But since the original, non-generalized tables were used for updating all generalized tables, even if nested over several levels, the wrong order didn't matter.